### PR TITLE
Make netstack (//pkg/tcpip) buildable for 32 bit

### DIFF
--- a/pkg/iovec/BUILD
+++ b/pkg/iovec/BUILD
@@ -6,10 +6,7 @@ go_library(
     name = "iovec",
     srcs = ["iovec.go"],
     visibility = ["//:sandbox"],
-    deps = [
-        "//pkg/abi/linux",
-        "@org_golang_x_sys//unix:go_default_library",
-    ],
+    deps = ["@org_golang_x_sys//unix:go_default_library"],
 )
 
 go_test(

--- a/pkg/iovec/iovec.go
+++ b/pkg/iovec/iovec.go
@@ -20,11 +20,11 @@ package iovec
 
 import (
 	"golang.org/x/sys/unix"
-	"gvisor.dev/gvisor/pkg/abi/linux"
 )
 
-// MaxIovs is the maximum number of iovecs host platform can accept.
-var MaxIovs = linux.UIO_MAXIOV
+// MaxIovs is the maximum number of iovecs host platform can accept. It
+// corresponds to Linux's UIO_MAXIOV, which is not in the unix package.
+var MaxIovs = 1024
 
 // Builder is a builder for slice of unix.Iovec.
 type Builder struct {
@@ -47,10 +47,9 @@ func (b *Builder) Add(buf []byte) {
 		b.addByAppend(buf)
 		return
 	}
-	b.iovec = append(b.iovec, unix.Iovec{
-		Base: &buf[0],
-		Len:  uint64(len(buf)),
-	})
+	iov := unix.Iovec{Base: &buf[0]}
+	iov.SetLen(len(buf))
+	b.iovec = append(b.iovec, iov)
 	// Keep the last buf if iovec is at max capacity. We will need to append to it
 	// for later bufs.
 	if len(b.iovec) == MaxIovs {
@@ -61,10 +60,9 @@ func (b *Builder) Add(buf []byte) {
 
 func (b *Builder) addByAppend(buf []byte) {
 	b.overflow = append(b.overflow, buf...)
-	b.iovec[len(b.iovec)-1] = unix.Iovec{
-		Base: &b.overflow[0],
-		Len:  uint64(len(b.overflow)),
-	}
+	iov := unix.Iovec{Base: &b.overflow[0]}
+	iov.SetLen(len(b.overflow))
+	b.iovec[len(b.iovec)-1] = iov
 }
 
 // Build returns the final Iovec slice. The length of returned iovec will not

--- a/pkg/tcpip/link/fdbased/endpoint.go
+++ b/pkg/tcpip/link/fdbased/endpoint.go
@@ -492,7 +492,7 @@ func (e *endpoint) sendBatch(batchFD int, batch []*stack.PacketBuffer) (int, tcp
 
 		var mmsgHdr rawfile.MMsgHdr
 		mmsgHdr.Msg.Iov = &iovecs[0]
-		mmsgHdr.Msg.Iovlen = uint64(len(iovecs))
+		mmsgHdr.Msg.SetIovlen((len(iovecs)))
 		mmsgHdrs = append(mmsgHdrs, mmsgHdr)
 	}
 

--- a/pkg/tcpip/link/fdbased/packet_dispatchers.go
+++ b/pkg/tcpip/link/fdbased/packet_dispatchers.go
@@ -68,10 +68,11 @@ func (b *iovecBuffer) nextIovecs() []unix.Iovec {
 		// The kernel adds virtioNetHdr before each packet, but
 		// we don't use it, so so we allocate a buffer for it,
 		// add it in iovecs but don't add it in a view.
-		b.iovecs[0] = unix.Iovec{
+		iov := unix.Iovec{
 			Base: &vnetHdr[0],
-			Len:  uint64(virtioNetHdrSize),
 		}
+		iov.SetLen(virtioNetHdrSize)
+		b.iovecs[0] = iov
 		vnetHdrOff++
 	}
 	for i := range b.views {
@@ -80,10 +81,11 @@ func (b *iovecBuffer) nextIovecs() []unix.Iovec {
 		}
 		v := buffer.NewView(b.sizes[i])
 		b.views[i] = v
-		b.iovecs[i+vnetHdrOff] = unix.Iovec{
+		iov := unix.Iovec{
 			Base: &v[0],
-			Len:  uint64(len(v)),
 		}
+		iov.SetLen(len(v))
+		b.iovecs[i+vnetHdrOff] = iov
 	}
 	return b.iovecs
 }
@@ -235,7 +237,7 @@ func (d *recvMMsgDispatcher) dispatch() (bool, tcpip.Error) {
 		iovLen := len(iovecs)
 		d.msgHdrs[k].Len = 0
 		d.msgHdrs[k].Msg.Iov = &iovecs[0]
-		d.msgHdrs[k].Msg.Iovlen = uint64(iovLen)
+		d.msgHdrs[k].Msg.SetIovlen(iovLen)
 	}
 
 	nMsgs, err := rawfile.BlockingRecvMMsg(d.fd, d.msgHdrs)

--- a/pkg/tcpip/transport/tcp/snd.go
+++ b/pkg/tcpip/transport/tcp/snd.go
@@ -323,7 +323,9 @@ func newSender(ep *endpoint, iss, irs seqnum.Value, sndWnd seqnum.Size, mss uint
 // their initial values.
 func (s *sender) initCongestionControl(congestionControlName tcpip.CongestionControlOption) congestionControl {
 	s.sndCwnd = InitialCwnd
-	s.sndSsthresh = math.MaxInt64
+	// Set sndSsthresh to the maximum int value, which depends on the
+	// platform.
+	s.sndSsthresh = int(^uint(0) >> 1)
 
 	switch congestionControlName {
 	case ccCubic:


### PR DESCRIPTION
Doing so involved breaking dependencies between //pkg/tcpip and the rest
of gVisor, which are discouraged anyways.

Tested on the Go branch via:
  gvisor.dev/gvisor/pkg/tcpip/...

Addresses #1446.

PiperOrigin-RevId: 362595105